### PR TITLE
 Fix incompatibility with other modules extending the layer config

### DIFF
--- a/src/controlButtons.js
+++ b/src/controlButtons.js
@@ -6,12 +6,21 @@ import * as BLOCKS from "./blocks.js";
 let oldVB_viewPosition;
 
 export function registerLayer() {
-  let canvasLayers = Canvas.layers;
-  canvasLayers.lockview = LockViewLayer;
+  CONFIG.Canvas.layers = foundry.utils.mergeObject(CONFIG.Canvas.layers, {
+    lockview: LockViewLayer
+  });
 
-  Object.defineProperty(Canvas, 'layers', {get: function() {
-    return canvasLayers
-  }})
+  // overriding other modules if needed
+  if (!Object.is(Canvas.layers, CONFIG.Canvas.layers)) {
+    console.error('Possible incomplete layer injection by other module detected!')
+
+    const layers = Canvas.layers
+    Object.defineProperty(Canvas, 'layers', {
+      get: function () {
+        return foundry.utils.mergeObject(layers, CONFIG.Canvas.layers)
+      }
+    })
+  }
 }
 
 class LockViewLayer extends CanvasLayer {


### PR DESCRIPTION
I investigated why the stairways module is incompatible with LockView and found that it's the same reason as with FX Master, which adds its layer in an sub-optimal. (see https://gitlab.com/SWW13/foundryvtt-stairways/-/issues/23#note_601720567 for a bit more details)

This patch should allow other modules to extend the layers config and decrease the chance of future breakage.

This patch (or a variation of it) is already applied to FXMaster ([patch 1](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster/-/commit/57588e804cd61a8001ded603c06ddc5058eb0787#8bc7a1d1718305918394da82b3617f909ef9c243_10_9), [patch 2](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster/-/commit/08188889d5e9b0671c6e053aa6a74dc8cac696eb)) and Automated Animations ([PR #106](https://github.com/otigon/automated-jb2a-animations/pull/106)).